### PR TITLE
add pm2 for node process management

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,4 +77,7 @@ Vagrant.configure(2) do |config|
     override.ssh.pty = true
   end
 
+  config.vm.provision "shell", inline: "pm2 start /home/vagrant/data/server.js",
+  run: "always"
+
 end

--- a/provision.sh
+++ b/provision.sh
@@ -12,3 +12,8 @@ if ! exists node; then
 curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
 sudo apt-get install -y nodejs
 fi
+
+# install pm2 (node process manager)
+if ! exists pm2; then
+npm install pm2 -g
+fi


### PR DESCRIPTION
This is for running `pm2` when vagrant set up with `up`, `reload`, or `provision`.
Now I can see what api server runs with `http://localhost:3000/api`, when vagrant is running.
